### PR TITLE
Fixed asset() cannot be used with absolute filesystem paths.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -8,13 +8,11 @@ module.exports = (config = {}) => {
 
   config = Object.assign({
     add_version: true,
+    asset_path_document_root: '',
   }, config);
 
   return {
     asset: (asset_path) => {
-      if (!config.asset_path_document_root) {
-        return asset_path;
-      }
       const absolute_path = path.join(config.asset_path_document_root, asset_path);
       if (config.add_version && fs.existsSync(absolute_path)) {
         const stats = fs.statSync(absolute_path);


### PR DESCRIPTION
### Problem
- When want to use the `asset()` function you have to have a base asset dir configured which is not desired if you want to pass in an absolute path already
- The asset function will fail (and return no version hash) if calling the asset function like this `asset('/absolute/path/to/asset.png')`

### Goal
- Allow using the asset function without the need of a configured base asset directory